### PR TITLE
Ensure D8.8 compatibility

### DIFF
--- a/src/Negotiator/CypressWorkspaceNegotiator.php
+++ b/src/Negotiator/CypressWorkspaceNegotiator.php
@@ -74,4 +74,9 @@ class CypressWorkspaceNegotiator implements WorkspaceNegotiatorInterface {
    */
   public function setActiveWorkspace(WorkspaceInterface $workspace) {}
 
+  /**
+   * {@inheritDoc}
+   */
+  public function unsetActiveWorkspace() {}
+
 }


### PR DESCRIPTION
Issue [2935780](https://www.drupal.org/project/drupal/issues/2935780) adds `unsetActiveWorkspace`-method to `WorkspaceNegotiatorInterface` which we need to implement for D8.8.x compatibility.