### PR TITLE
Response headers fix

### DIFF
--- a/cypress.services.yml
+++ b/cypress.services.yml
@@ -7,6 +7,12 @@ parameters:
   cypress.executable.drush: 'drush'
 
 services:
+  # Remove error headers since they might break cypress.
+  cypress.event_subscriber.remove_error_headers:
+    class: Drupal\cypress\EventSubscriber\RemoveErrorHeadersSubscriber
+    tags:
+      - { name: 'event_subscriber' }
+
   # Directory parameters
   cypress.root.factory:
     class: Drupal\cypress\CypressRootFactory

--- a/src/EventSubscriber/RemoveErrorHeadersSubscriber.php
+++ b/src/EventSubscriber/RemoveErrorHeadersSubscriber.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\cypress\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Removes X-Drupal-Assertion-* headers since Cypress chokes on them.
+ */
+class RemoveErrorHeadersSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Filter already registered headers.
+   *
+   * Remove all occurrences of X-Drupal-Assertion-* to make sure Cypress
+   * doesn't exit with an parse error as soon as it receives the header.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   */
+  public function onResponse(FilterResponseEvent $event) {
+    if (DRUPAL_TEST_IN_CHILD_SITE) {
+      $prefix = 'X-Drupal-Assertion-';
+      $count = 0;
+      foreach (headers_list() as $header) {
+        if (substr($header, 0, strlen($prefix)) === $prefix) {
+          header_remove($prefix . $count++);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::RESPONSE => [['onResponse']],
+    ];
+  }
+
+}

--- a/tests/Cypress/integration/Scripts.feature
+++ b/tests/Cypress/integration/Scripts.feature
@@ -9,7 +9,7 @@ Feature: Script execution
     Then the status test shows the test site as site directory
 
   Scenario: Execute a Drupal script
-    Given the test case uses 'cy.drupalSession' to authenticate in as "admin"
+    Given the test case uses 'cy.drupalSession' to authenticate as "admin"
     And the test case uses 'cy.drupalScript' to create a page with title "Testpage"
     When the test accesses the main content listing
     Then there should be an entry for the page with title "Testpage"

--- a/tests/Cypress/integration/Session.feature
+++ b/tests/Cypress/integration/Session.feature
@@ -6,20 +6,20 @@ Feature: Session management
   this way also persist during further navigation.
 
   Scenario: Authentication
-    Given the test case uses 'cy.drupalSession' to authenticate in as "admin"
+    Given the test case uses 'cy.drupalSession' to authenticate as "admin"
     When the test case visits the homepage and clicks the link to the "admin" account
     Then then the "admin" account page should be displayed
 
   Scenario: Toolbar
     Given the "toolbar" module is installed
-    And the test case uses 'cy.drupalSession' to authenticate in as "admin"
+    And the test case uses 'cy.drupalSession' to authenticate as "admin"
     And the test case uses 'cy.drupalSession' to display the toolbar
     When the test case visits the homepage and clicks the link to the "admin" account
     Then the toolbar should be visible
 
   Scenario: Workspace
     Given the "workspace" module is installed
-    And the test case uses 'cy.drupalSession' to authenticate in as "admin"
+    And the test case uses 'cy.drupalSession' to authenticate as "admin"
     And the test case uses 'cy.drupalSession' to switch to workspace "stage"
     And the test case uses 'cy.drupalSession' to display the toolbar
     When the test case visits the homepage and clicks the link to the "admin" account
@@ -29,6 +29,6 @@ Feature: Session management
     Given the "language" module is installed
     And the language "German" is enabled
     And the test case uses 'cy.drupalSession' to display switch to "German"
-    And the test case uses 'cy.drupalSession' to authenticate in as "admin"
+    And the test case uses 'cy.drupalSession' to authenticate as "admin"
     When the test case visits the homepage and clicks the link to the "admin" account
     Then the page is displayed in "German"

--- a/tests/Cypress/integration/steps.js
+++ b/tests/Cypress/integration/steps.js
@@ -16,7 +16,7 @@ afterEach(() => {
 });
 
 // Given a test case uses 'cy.drupalSession' to authenticate in as "admin"
-Given(/^the test case uses 'cy.drupalSession' to authenticate in as "([^"]*)"$/, function (account) {
+Given(/^the test case uses 'cy.drupalSession' to authenticate as "([^"]*)"$/, function (account) {
   cy.drupalSession({user: account});
 });
 


### PR DESCRIPTION
When the response header is too large, Cypress bails out with a `Parse Error`. This can happen when too many deprecation errors are found in a test site. So we filter the headers since they are not used in cypress anyway.