### PR TITLE
Full error messages

### DIFF
--- a/tests/Cypress/support/commands.js
+++ b/tests/Cypress/support/commands.js
@@ -97,3 +97,24 @@ Cypress.Commands.add('drupalVisitEntity', (type, query, link = 'canonical') => {
   const params = Object.keys(query).map(key => `${key}=${encodeURI(query[key])}`).join('&');
   cy.visit(`/cypress/entity/${type}/${link}?${params}`);
 });
+
+Cypress.Commands.overwrite('exec', (originalFn, command, options) => {
+  // failOnNonZeroExit is true by default.
+  const failOnNonZeroExit = (
+    !options ||
+    !options.hasOwnProperty('failOnNonZeroExit') ||
+    options.failOnNonZeroExit
+  );
+  return originalFn(command, {...options, failOnNonZeroExit: false}).then(result => {
+    if (failOnNonZeroExit && result.code) {
+
+      // Show the full error message instead of the default trimmed one. This is
+      // a workaround for https://github.com/cypress-io/cypress/issues/5470
+      throw new Error(`Execution of "${command}" failed
+      Exit code: ${result.code}
+      Stdout:\n${result.stdout}
+      Stderr:\n${result.stderr}`);
+    }
+    return result;
+  });
+});


### PR DESCRIPTION
This is a workaround for https://github.com/cypress-io/cypress/issues/5470 to prevent the following confusion:
<img width="472" alt="Screenshot_2019-12-30_at_11_21_00" src="https://user-images.githubusercontent.com/989015/71577592-d2d18a00-2b05-11ea-83fa-63186442a1bb.png">
