### PR TITLE
Print broken JSON in the error message

### DIFF
--- a/tests/Cypress/support/commands.js
+++ b/tests/Cypress/support/commands.js
@@ -77,7 +77,12 @@ Cypress.Commands.add('drupalInstall', (options) => {
     },
     timeout: 3000000
   }).then(result => {
-    const installData = JSON.parse(result.stdout);
+    let installData;
+    try {
+      installData = JSON.parse(result.stdout);
+    } catch (e) {
+      throw new Error(`Cannot parse JSON:\n${result.stdout}`);
+    }
     Cypress.env('DRUPAL_DB_PREFIX', installData.db_prefix);
     Cypress.env('DRUPAL_SITE_PATH', installData.site_path);
     Cypress.env('SIMPLETEST_USER_AGENT', installData.user_agent);


### PR DESCRIPTION
Error message before:
```
SyntaxError: Unexpected token < in JSON at position 0
```

Error message after:
```
Error: Cannot parse JSON:
<!DOCTYPE html>
...
                  <li>The configuration synchronization failed validation.</li>
                  <li>The selected installation profile <em class="placeholder">testing</em> does not match the profile stored in configuration <em class="placeholder">minimal</em>.</li>
...
```