### PR TITLE
Increase Node.js max-http-header-size

### DIFF
--- a/src/Cypress.php
+++ b/src/Cypress.php
@@ -8,6 +8,17 @@ namespace Drupal\cypress;
 class Cypress implements CypressInterface {
 
   /**
+   * Environment variables to be used with Cypress.
+   */
+  const ENVIRONMENT_VARIABLES = [
+    // Increase Node.js max header size to prevent issues with Drupal's
+    // debug_cacheability_headers option which is enabled by
+    // \Drupal\Core\Test\FunctionalTestSetupTrait::initSettings() during the
+    // Drupal installation.
+    'NODE_OPTIONS' => '--max-http-header-size=80000',
+  ];
+
+  /**
    * A process manager to execute cypress commands.
    *
    * @var \Drupal\cypress\ProcessManagerInterface
@@ -133,7 +144,7 @@ class Cypress implements CypressInterface {
     $args = $cypressOptions->getCliOptions();
     array_unshift($args, 'run');
     array_unshift($args, $this->cypressExecutable);
-    $this->processManager->run($args, $this->cypressRoot);
+    $this->processManager->run($args, $this->cypressRoot, self::ENVIRONMENT_VARIABLES);
   }
 
   /**
@@ -144,6 +155,6 @@ class Cypress implements CypressInterface {
     $args = $cypressOptions->getCliOptions();
     array_unshift($args, 'open');
     array_unshift($args, $this->cypressExecutable);
-    $this->processManager->run($args, $this->cypressRoot);
+    $this->processManager->run($args, $this->cypressRoot, self::ENVIRONMENT_VARIABLES);
   }
 }

--- a/src/TtyProcessManager.php
+++ b/src/TtyProcessManager.php
@@ -15,6 +15,7 @@ class TtyProcessManager implements ProcessManagerInterface {
    */
   public function run(array $commandLine, $workingDirectory, $environment = []) {
     $process = new Process($commandLine, $workingDirectory);
+    $process->inheritEnvironmentVariables(TRUE);
     $process->setTty(Tty::isTtySupported());
     $process->setTimeout(0.0);
     $process->setIdleTimeout(0.0);

--- a/tests/Unit/CypressTest.php
+++ b/tests/Unit/CypressTest.php
@@ -55,7 +55,8 @@ class CypressTest extends UnitTestCase {
   public function testCypressRun() {
     $this->processManager->run(
       ['/app/node_modules/.bin/cypress', 'run', '--spec', 'bar'],
-      '/app/drupal-cypress-environment'
+      '/app/drupal-cypress-environment',
+      Cypress::ENVIRONMENT_VARIABLES
     )->shouldBeCalledOnce();
     $this->cypress->run($this->options);
   }
@@ -63,7 +64,8 @@ class CypressTest extends UnitTestCase {
   public function testCypressOpen() {
     $this->processManager->run(
       ['/app/node_modules/.bin/cypress', 'open', '--spec', 'bar'],
-      '/app/drupal-cypress-environment'
+      '/app/drupal-cypress-environment',
+      Cypress::ENVIRONMENT_VARIABLES
     )->shouldBeCalledOnce();
     $this->cypress->open($this->options);
   }


### PR DESCRIPTION
This is to prevent the following:
```
CypressError: cy.request() failed trying to load:

http://localhost:8889/cypress/script

We attempted to make an http request to this URL but the request failed without a response.

We received this error at the network level:

  > Error: Parse Error: Header overflow
```