### PR TITLE
Catch errors in Drupal scripts

### DIFF
--- a/src/Controller/ScriptController.php
+++ b/src/Controller/ScriptController.php
@@ -44,7 +44,12 @@ class ScriptController extends ControllerBase {
     $args = $content->args ?? [];
 
     ob_start();
-    include $path;
+    try {
+      include $path;
+    }
+    catch (\Throwable $e) {
+      return new Response($e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
     $response = ob_get_clean();
 
     return new Response($response);


### PR DESCRIPTION
If an error happens in a Drupal script, Cypress displays:
- before: the standard Drupal's 500 error response
- after: the actual error message
