### PR TITLE
Fix merging of dependencies

### DIFF
--- a/src/NpmProjectManager.php
+++ b/src/NpmProjectManager.php
@@ -83,6 +83,8 @@ class NpmProjectManager implements NpmProjectManagerInterface {
     }
 
     unset($merge['dependencies']);
+    // Re-read package.json since it could be modified by ensurePackageVersion.
+    $packageJson = json_decode(file_get_contents($this->packageDirectory . '/package.json'), TRUE);
     $packageJson = NestedArray::mergeDeep($packageJson, $merge);
 
     $this->fileSystem->dumpFile(


### PR DESCRIPTION
The bug: when there are more than one suites having `package.json` files, only dependencies of the last processed suite are installed. This happens because `NpmProjectManager::ensurePackageVersion()` modifies `package.json`, but those changes are never read in `NpmProjectManager::merge()`.

I haven't add any tests for this because I think that merging should be re-done. I opened https://github.com/AmazeeLabs/cypress/issues/25 for this.