### PR TITLE
Generate test user agent after Drupal is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
   - phpenv config-rm xdebug.ini
   # Composer  setup
   - composer self-update
+  - composer config -g github-oauth.github.com $COMPOSER_GITHUB_TOKEN
   # Download and unpack Drupal
   - curl -O https://ftp.drupal.org/files/projects/drupal-$DRUPAL_VERSION.tar.gz
   - tar -xf drupal-$DRUPAL_VERSION.tar.gz -C $TRAVIS_BUILD_DIR/../

--- a/src/TestSite/TestSiteInstallCommand.php
+++ b/src/TestSite/TestSiteInstallCommand.php
@@ -110,10 +110,9 @@ class TestSiteInstallCommand extends CoreTestSiteInstallCommand {
     $setupScript = new $setup_class();
 
     $drush = getenv('DRUPAL_DRUSH') ?: 'drush';
-    $drushEnv = ['HTTP_USER_AGENT' => drupal_generate_test_ua($this->databasePrefix)] + $_SERVER;
 
     $cachedInstallation->install(
-      function () use ($setupScript, $drush, $drushEnv) {
+      function () use ($setupScript, $drush) {
         $this->installDrupal();
 
         if (getenv('DRUPAL_CONFIG_DIR')) {
@@ -122,13 +121,15 @@ class TestSiteInstallCommand extends CoreTestSiteInstallCommand {
           // it changes the default theme.
           // Avoid this with an additional config import.
           $command = [$drush, 'cim', '-y'];
+          $drushEnv = ['HTTP_USER_AGENT' => drupal_generate_test_ua($this->databasePrefix)] + $_SERVER;
           (new Process($command, getenv('DRUPAL_APP_ROOT'), $drushEnv, NULL, 0))
             ->mustRun();
         }
 
         $setupScript->setup();
       },
-      function () use ($drush, $drushEnv) {
+      function () use ($drush) {
+        $drushEnv = ['HTTP_USER_AGENT' => drupal_generate_test_ua($this->databasePrefix)] + $_SERVER;
         foreach ([
                    [$drush, 'cr'],
                    [$drush, 'updb', '-y'],


### PR DESCRIPTION
This is required because in some cases a Drupal installation may take more that 10 minutes which hits the limit in drupal_valid_test_ua(). See https://github.com/drupal/drupal/blob/8.8.4/core/includes/bootstrap.inc#L695